### PR TITLE
refactor serializeLinks data chan

### DIFF
--- a/repsonse.go
+++ b/repsonse.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"time"
+)
+
+// Response represents a response to a request for momentos
+type Response struct {
+	// originally requested uri
+	OriginalUri string `json:""`
+	// request represented as a uri
+	Self string `json:"self"`
+	// list of returned momentos from different archive services
+	Mementos MementoList `json:"mementos"`
+	// Object of uris that point to timemap urls in different formats
+	TimemapUri TimemapUri `json:"timemap_uri"`
+	// Url for timegate
+	TimegateUri string `json:"timegate_uri"`
+}
+
+// MementoList is a wrapper for presenting a list of momentos
+type MementoList struct {
+	List []DatetimeUri `json:"list"`
+}
+
+// DatetimeUri combines a uri with a datestamp
+type DatetimeUri struct {
+	Datetime time.Time `json:"datetime"`
+	Uri      string    `json:"uri"`
+}
+
+// TimemapUri is a list of uris that contains timemap
+// uris in different formats
+type TimemapUri struct {
+	LinkFormat string `json:"link_format"`
+	JsonFormat string `json:"json_format"`
+	CdxjFormat string `json:"cdxj_format"`
+}


### PR DESCRIPTION
👋 

As promised, here's a very small first step on refactoring memgator. I've intentionally kept the changes very light, as we don't have a test suite in place.

This PR refactors the `dataCh` argument to `serializeLinks`, changing it's type from `dataCh chan string` to `dataCh chan fmt.Stringer`. All processes that read from `dataCh` now call `.String()` on the result to get the string they would previously output.

Which may seem like a small change, it opens up a number of improvements down the road, (which we can make with incremental PRs). Instead of the channel needing to accept an explicit string, it now accepts _anything that can produce a string_, we end up using this new feature immediately in the `serializeLinks` func, passing back raw buffers (`bytes.Buffer` has a built-in `String() string` method). And this sets the stage for returning one or more custom structs, each with a string method that cleans up the code inside the formatting switch of `serializeLinks`.

I'd recommend checking extensively on your end to make sure I haven't broken anything ☺️, but if you're into this PR there are a number of change we can make from here as a team. Feedback of all kinds welcomed.

