### PR TITLE
Fix crossbuild script to continue after invalid arch.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,18 +6,18 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-go@master
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
         with:
-          go-version: '1.14'
+          go-version: '1.16'
       - name: Run Cross-build
         run: ./crossbuild.sh
       - name: Show MemGator CLI Help
         run: /tmp/mgbins/memgator-linux-amd64
       - name: Upload Built MemGator Binaries
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v2
         with:
           name: memgator-bins
           path: /tmp/mgbins

--- a/crossbuild.sh
+++ b/crossbuild.sh
@@ -7,6 +7,7 @@ echo "Building binaries for various platforms"
 # Create directory to store all binaries
 binsdir=/tmp/mgbins
 mkdir -p $binsdir
+rm -rf $binsdir/memgator-*
 echo "Output directory for binaries created: $binsdir"
 
 # Platforms (OS/arch matrix)

--- a/crossbuild.sh
+++ b/crossbuild.sh
@@ -21,7 +21,9 @@ for os in $oses; do
     if [ $os == "windows" ]; then
       GOOS=$os GOARCH=$arc go build -v -o $fn.exe
     else
-      GOOS=$os GOARCH=$arc CGO_ENABLED=0 go build -v -a -installsuffix cgo -o $fn
+      GOOS=$os GOARCH=$arc CGO_ENABLED=0 go build -v -a -installsuffix cgo -o $fn || {
+        echo "Failed to build $os/$arc"
+      }
     fi
   done
 done

--- a/crossbuild.sh
+++ b/crossbuild.sh
@@ -27,4 +27,4 @@ for p in $platforms; do
 done
 
 echo "Following binaries have been created in: $binsdir"
-ls -lh $binsdir
+(cd /tmp/mgbins/ && ls -lh memgator-*)

--- a/crossbuild.sh
+++ b/crossbuild.sh
@@ -11,7 +11,7 @@ rm -rf $binsdir/memgator-*
 echo "Output directory for binaries created: $binsdir"
 
 # Platforms (OS/arch matrix)
-platforms="linux/amd64 darwin/amd64 windows/amd64"
+platforms="linux/amd64 darwin/amd64 windows/amd64 darwin/arm64"
 
 # Build binaries for all listed platforms
 for p in $platforms; do

--- a/crossbuild.sh
+++ b/crossbuild.sh
@@ -27,4 +27,4 @@ for p in $platforms; do
 done
 
 echo "Following binaries have been created in: $binsdir"
-(cd /tmp/mgbins/ && ls -lh memgator-*)
+(cd $binsdir && ls -lh memgator-*)

--- a/crossbuild.sh
+++ b/crossbuild.sh
@@ -9,23 +9,20 @@ binsdir=/tmp/mgbins
 mkdir -p $binsdir
 echo "Output directory for binaries created: $binsdir"
 
-# OS and architecture matrix
-oses="linux darwin windows"
-arcs="386 amd64"
+# Platforms (OS/arch matrix)
+platforms="linux/amd64 darwin/amd64 windows/amd64"
 
-# Build binaries for all OSes and architectures
-for os in $oses; do
-  for arc in $arcs; do
-    echo "Building binary for $os/$arc"
-    fn=$binsdir/memgator-$os-$arc
-    if [ $os == "windows" ]; then
-      GOOS=$os GOARCH=$arc go build -v -o $fn.exe
-    else
-      GOOS=$os GOARCH=$arc CGO_ENABLED=0 go build -v -a -installsuffix cgo -o $fn || {
-        echo "Failed to build $os/$arc"
-      }
-    fi
-  done
+# Build binaries for all listed platforms
+for p in $platforms; do
+  os=${p%/*}
+  arc=${p#*/}
+  echo "Building binary for platform: $p"
+  fn=$binsdir/memgator-$os-$arc
+  if [ $os == "windows" ]; then
+    GOOS=$os GOARCH=$arc go build -v -o $fn.exe
+  else
+    GOOS=$os GOARCH=$arc CGO_ENABLED=0 go build -v -a -installsuffix cgo -o $fn
+  fi
 done
 
 echo "Following binaries have been created in: $binsdir"


### PR DESCRIPTION
This PR accounts for invalid architectures in the crossbuild script and closes #135.

I adjusted the bash script to print a message if the architecture combo used to build fails. Executing the revised script produces the binaries in /tmp/mgbins: memgator-darwin-amd64, memgator-windows-386.exe, memgator-linux-386, memgator-windows-amd64.exe, memgator-linux-amd64.

