### PR TITLE
Add National Library of Israel to archives.json

### DIFF
--- a/docs/archives.json
+++ b/docs/archives.json
@@ -115,5 +115,11 @@
     "timemap": "http://webarchive.proni.gov.uk/timemap/",
     "timegate": "http://webarchive.proni.gov.uk/timegate/",
     "ignore": true
+  },
+  {
+    "id": "wayback.nli.org.il",
+    "name": "National Library of Israel",
+    "timemap": "https://wayback.nli.org.il/timemap/link/",
+    "timegate": "https://wayback.nli.org.il/"
   }
 ]


### PR DESCRIPTION
Per #139, it now appear the archive is using https. One concern is whether the label should be what is in the logo (National Library of Israel) or the OpenWayback instance's HTML title (Israeli Internet Archive).

Because of this, I am hoping for a review.