### PR TITLE
Handle escaped URI-Rs

### DIFF
--- a/main.go
+++ b/main.go
@@ -477,6 +477,7 @@ func parseURI(uri string) (urir string, err error) {
 		logError.Printf("Error Unescaping path (%s): %v", uri, err)
 		return
 	}
+	uescd = strings.ReplaceAll(uescd, " ", "%20")
 	if !regs["isprtcl"].MatchString(uescd) {
 		uescd = "http://" + uescd
 	}

--- a/main.go
+++ b/main.go
@@ -472,9 +472,9 @@ func aggregateTimemap(urir string, dttmp *time.Time, sess *Session) (basetm *lis
 }
 
 func parseURI(uri string) (urir string, err error) {
-	uescd, err := url.QueryUnescape(uri)
+	uescd, err := url.PathUnescape(uri)
 	if !regs["isprtcl"].MatchString(uescd) {
-		uescd = "http://" + uri
+		uescd = "http://" + uescd
 	}
 
 	u, err := url.Parse(uescd)

--- a/main.go
+++ b/main.go
@@ -473,22 +473,17 @@ func aggregateTimemap(urir string, dttmp *time.Time, sess *Session) (basetm *lis
 
 func parseURI(uri string) (urir string, err error) {
 	uescd, err := url.PathUnescape(uri)
-
 	if err != nil {
 		logError.Printf("Error Unescaping path (%s): %v", uri, err)
 		return
 	}
-
 	if !regs["isprtcl"].MatchString(uescd) {
 		uescd = "http://" + uescd
 	}
-
 	u, err := url.Parse(uescd)
-
 	if err == nil {
 		urir = u.String()
 	}
-
 	return
 }
 

--- a/main.go
+++ b/main.go
@@ -472,13 +472,17 @@ func aggregateTimemap(urir string, dttmp *time.Time, sess *Session) (basetm *lis
 }
 
 func parseURI(uri string) (urir string, err error) {
-	if !regs["isprtcl"].MatchString(uri) {
-		uri = "http://" + uri
+	uescd, err := url.QueryUnescape(uri)
+	if !regs["isprtcl"].MatchString(uescd) {
+		uescd = "http://" + uri
 	}
-	u, err := url.Parse(uri)
+
+	u, err := url.Parse(uescd)
+
 	if err == nil {
 		urir = u.String()
 	}
+
 	return
 }
 

--- a/main.go
+++ b/main.go
@@ -473,6 +473,12 @@ func aggregateTimemap(urir string, dttmp *time.Time, sess *Session) (basetm *lis
 
 func parseURI(uri string) (urir string, err error) {
 	uescd, err := url.PathUnescape(uri)
+
+	if err != nil {
+		logError.Printf("Error Unescaping path (%s): %v", uri, err)
+		return
+	}
+
 	if !regs["isprtcl"].MatchString(uescd) {
 		uescd = "http://" + uescd
 	}


### PR DESCRIPTION
Closes #110

I also tested URIs that would get decoded as spaces, e.g.,

`curl -i "http://localhost:1208/timemap/link/http%3A%2F%2Fexample.org%2F%20index.html"`

The %20 remains in the URIR after being decoded.