### PR TITLE
👷 Modernize Docker publish workflow with ARM64 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.16'
       - name: Run Cross-build
@@ -17,7 +17,7 @@ jobs:
       - name: Show MemGator CLI Help
         run: /tmp/mgbins/memgator-linux-amd64
       - name: Upload Built MemGator Binaries
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: memgator-bins
           path: /tmp/mgbins

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,30 +9,44 @@ on:
       - published
 
 jobs:
-  publish-master:
-    runs-on: ubuntu-20.04
-    if: github.ref == 'refs/heads/master'
+  publish:
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - name: Build and Publish master
-        uses: VaultVulp/gp-docker-action@master
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          image-name: memgator
-          image-tag: master
-  publish-release:
-    runs-on: ubuntu-20.04
-    if: startsWith(github.ref, 'refs/tags/')
-    steps:
-      - uses: actions/checkout@master
-      - name: Build and Publish latest
-        uses: VaultVulp/gp-docker-action@master
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          image-name: memgator
-      - name: Build and Publish versioned
-        uses: VaultVulp/gp-docker-action@master
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          image-name: memgator
-          extract-git-tag: true
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,10 @@ ARG        ALPINE_TAG=latest
 
 FROM       golang:${GOLANG_TAG} AS builder
 
+ARG        TARGETARCH
 WORKDIR    /app
 COPY       . .
-RUN        GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go install -ldflags="-w -s"
+RUN        GOOS=linux GOARCH=${TARGETARCH} CGO_ENABLED=0 go install -ldflags="-w -s"
 
 
 FROM       alpine:${ALPINE_TAG}


### PR DESCRIPTION
Hi team! Thank you for maintaining this awesome tool ❤️ 
I noticed that arm docker image is not being publish on this project. We have potential demand to run this on arm machine, I've added `linux/arm64` support to the workflow. Please feel free to review 🙏 

## Summary
- Replaced non-standard `VaultVulp/gp-docker-action` with official Docker actions
- Added multi-architecture support for `linux/amd64` and `linux/arm64`
- Updated Dockerfile to use `TARGETARCH` for cross-platform builds
- Modernized GitHub Actions versions in build workflow

## Changes
- **Dockerfile**: Added `TARGETARCH` build arg to support multi-platform builds
- **publish.yml**: Rewrote using `docker/build-push-action` with buildx for ARM64 support
- **build.yml**: Updated action versions to latest (v4/v5)

Images will now be published to GitHub Container Registry with multi-architecture support.